### PR TITLE
cure acceleration act

### DIFF
--- a/app/dfda/components/DFDADisclaimer.tsx
+++ b/app/dfda/components/DFDADisclaimer.tsx
@@ -67,7 +67,7 @@ export function DFDADisclaimer({ children }: DFDADisclaimerProps) {
               the highest standards of safety and efficacy.
             </p>
             <p>
-              Help us transform healthcare by signing the Right to Trial Act
+              Help us transform healthcare by signing the Cure Acceleration Act
               petition, which aims to update FDA.gov to support automated and
               decentralized clinical trials.
             </p>

--- a/app/dfda/components/DFDADisclaimerModal.tsx
+++ b/app/dfda/components/DFDADisclaimerModal.tsx
@@ -19,7 +19,7 @@ export function DFDADisclaimerModal({
             highest standards of safety and efficacy.
           </p>
           <p>
-            Help us transform healthcare by signing the Right to Trial Act
+            Help us transform healthcare by signing the Cure Acceleration Act
             petition, which aims to update FDA.gov to support automated and
             decentralized clinical trials.
           </p>

--- a/app/dfda/components/dfda-home-page.tsx
+++ b/app/dfda/components/dfda-home-page.tsx
@@ -36,7 +36,7 @@ export default function DFDAHomePage() {
       icon: Scroll,
       media: "https://wiki.dfda.earth/right_to_trial_act_image.jpg",
       onClick: async () => {
-        console.log("Right to Trial Act clicked")
+        console.log("Cure Acceleration Act clicked")
         setIsLoading(true)
         router.push("/dfda/right-to-trial-act")
       },

--- a/app/dfda/right-to-trial-act/components/Header.tsx
+++ b/app/dfda/right-to-trial-act/components/Header.tsx
@@ -2,7 +2,7 @@ export default function Header() {
   return (
     <header className="mb-8 border-4 border-black bg-white p-6 text-center shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
       <h1 className="mb-4 text-5xl font-black uppercase tracking-tight">
-        RIGHT TO TRIAL ACT 🧪💊
+        CURE ACCELERATION ACT 🧪💊
       </h1>
       <p className="text-xl font-bold">
         Faster Cures, Lower Costs, Universal Access 🚀🏥

--- a/app/dfda/right-to-trial-act/components/problems-with-the-current-system.tsx
+++ b/app/dfda/right-to-trial-act/components/problems-with-the-current-system.tsx
@@ -80,9 +80,6 @@ const ProblemsWithCurrentSystem = () => {
         <h2 className="mb-4 text-4xl font-black uppercase tracking-tight">
           Problems With The Current System 🏥
         </h2>
-        <p className="text-xl font-bold">
-          Our healthcare system is failing billions of people. Here's why:
-        </p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/app/dfda/right-to-trial-act/components/right-to-trial-act.tsx
+++ b/app/dfda/right-to-trial-act/components/right-to-trial-act.tsx
@@ -26,7 +26,7 @@ export default function CureAccelerationAct() {
           <h2 className="neobrutalist-h2">Overview & Findings 📜</h2>
           <h3 className="neobrutalist-h3">Title 🏷️</h3>
           <p className="neobrutalist-p">
-            This Act may be cited as the "Right to Trial Act" 📋
+            This Act may be cited as the "Cure Acceleration Act" 📋
           </p>
           <ProblemsWithCurrentSystem />
           <RightToTrialActSolutions />

--- a/app/dfda/right-to-trial-act/page.tsx
+++ b/app/dfda/right-to-trial-act/page.tsx
@@ -10,7 +10,7 @@ import { FloatingPetitionButton } from "./components/FloatingPetitionButton"
 import CureAccelerationAct from "./components/right-to-trial-act"
 
 export const metadata: Metadata = {
-  title: "Right to Trial Act | DFDA",
+  title: "Cure Acceleration Act | DFDA",
   description: "Faster Cures, Lower Costs, Universal Access 🚀",
 }
 export default async function RightToTrialPage() {

--- a/app/petitions/components/SignPetitionButton.tsx
+++ b/app/petitions/components/SignPetitionButton.tsx
@@ -25,7 +25,7 @@ export function SignPetitionButton({
   hasSigned: initialHasSigned,
   status = "ACTIVE",
   className,
-  signedClassName,
+  signedClassName, 
   onSignatureChange,
   buttonVariant = "default",
 }: SignPetitionButtonProps) {

--- a/config/navigation/domains/dfda-nav.ts
+++ b/config/navigation/domains/dfda-nav.ts
@@ -27,10 +27,10 @@ export const dfdaLinks = {
     tooltip: "An autonomous AI Food and Drug Administration",
   },
   petition: {
-    title: "Right to Trial Act",
+    title: "Cure Acceleration Act",
     href: "/dfda/right-to-trial-act",
     icon: "petition",
-    tooltip: "Help us transform healthcare by signing the Right to Trial Act",
+    tooltip: "Help us transform healthcare by signing the Cure Acceleration Act",
   },
   healthSavingsSharing: {
     title: "50/50 Health Savings Sharing Program",

--- a/public/globalSolutions/dfda/patient-industrial-complex.md
+++ b/public/globalSolutions/dfda/patient-industrial-complex.md
@@ -3,7 +3,7 @@
 ## 📜 Overview
 
 The Patient Industrial Complex (PIC) uses tokens to reward actions that advance
-the [Right to Trial Act](https://wishonia.love/dfda/right-to-trial-act) and reduce patient suffering. The token has no
+the [Cure Acceleration Act](https://wishonia.love/dfda/right-to-trial-act) and reduce patient suffering. The token has no
 intrinsic value - it's simply a point system to incentivize and coordinate collective action.
 
 ## 🎁 Rewarded Actions & Impact

--- a/public/globalSolutions/dfda/problems/deaths-due-to-us-regulatory-drug-lag.md
+++ b/public/globalSolutions/dfda/problems/deaths-due-to-us-regulatory-drug-lag.md
@@ -1,10 +1,9 @@
 ---
 description: >-
-  A comparative analysis between countries suggests that delays in new
-  interventions cost anywhere from 21,000 to 120, 000 US lives per decade.
+  Delays in new interventions cost anywhere from 21,000 to 120,000 US lives per decade.
 ---
 
-# ⏱ Deaths Due to US Regulatory "Drug Lag"
+# ⏱ Deaths Due to Regulatory "Drug Lag"
 
 **Delayed Life-Saving Treatments**
 

--- a/public/globalSolutions/dfda/problems/lack-of-incentive-to-discover-the-full-range-of-applications-for-off-patent-treatments.md
+++ b/public/globalSolutions/dfda/problems/lack-of-incentive-to-discover-the-full-range-of-applications-for-off-patent-treatments.md
@@ -1,3 +1,0 @@
-# 📃 Lack of Incentive to Discover the Full Range of Applications for Off-Patent Treatments
-
-There are roughly [10,000](https://www.washingtonpost.com/news/fact-checker/wp/2016/11/17/are-there-really-10000-diseases-and-500-cures/) known diseases afflicting humans, most of which (approximately 95%) are classified as “orphan” (rare) diseases. The current system requires that a pharmaceutical company predict a particular condition in advance of running clinical trials. If a drug is found to be effective for other diseases after the patent has expired, no one has the financial incentive to get it approved for another disease.

--- a/public/globalSolutions/dfda/problems/no-data-on-unpatentable-molecules.md
+++ b/public/globalSolutions/dfda/problems/no-data-on-unpatentable-molecules.md
@@ -5,7 +5,7 @@ description: >-
   every day.
 ---
 
-# 🥫 No Data on Unpatentable Molecules
+# 🥫 No Data on Unpatentable Treatments
 
 Under the current system of research, it costs [$41k](https://www.clinicalleader.com/doc/getting-a-handle-on-clinical-trial-costs-0001) per subject in Phase III clinical trials. As a result, there is not a sufficient profit incentive for anyone to research the effects of any factor besides a molecule that can be patented.
 

--- a/public/globalSolutions/dfda/problems/people-with-rare-disease-are-severely-punished.md
+++ b/public/globalSolutions/dfda/problems/people-with-rare-disease-are-severely-punished.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  In the case of rare diseases, increasing the cost of treatment development to
-  over a billion makes it impossible to recover your investment from a small
+  It's impossible to recover a billion dollars of drug development from a small
   number of patients.
 ---
 

--- a/public/globalSolutions/dfda/problems/we-know-nothing.md
+++ b/public/globalSolutions/dfda/problems/we-know-nothing.md
@@ -1,10 +1,10 @@
 ---
-description: We only know 0.000000002% of what is left to be known.
+description: We've only studied 0.000000002% of potential treatments.
 ---
 
 # ❓ We Know Next to Nothing
 
-We’re only 2 lifetimes from the use of the modern scientific method in medicine. Thus, it's only been applied for 0.0001% of human history. The more clinical research studies we read, the more we realize we don’t know. Nearly every study ends with the phrase "more research is needed". We know basically nothing at this point compared to what will eventually be known about the human body.
+We’re only 2 lifetimes from the use of the modern scientific method in medicine. Thus, it's only been applied for 0.0001% of human history. The more clinical research studies we read, the more we realize we don’t know. Nearly every study ends with the phrase, "More research is needed." We know basically nothing at this point compared to what will eventually be known about the human body.
 
 There are over [7,000](https://www.washingtonpost.com/news/fact-checker/wp/2016/11/17/are-there-really-10000-diseases-and-500-cures/) known diseases afflicting humans.
 

--- a/public/globalSolutions/dfda/right-to-trial-act-details.md
+++ b/public/globalSolutions/dfda/right-to-trial-act-details.md
@@ -1,10 +1,10 @@
-# Right to Trial Act
+# Cure Acceleration Act
 
 ## Section 1. Short Title and Findings
 
 ### 1.1 Title
 
-Cited as the "Right to Trial Act."
+Cited as the "Cure Acceleration Act."
 
 ### 1.2 Core Findings
 

--- a/public/globalSolutions/dfda/right-to-trial-act-summary.md
+++ b/public/globalSolutions/dfda/right-to-trial-act-summary.md
@@ -1,4 +1,4 @@
-# 💖 RIGHT TO TRIAL ACT: Executive Summary
+# 💖 CURE ACCELERATION ACT: Executive Summary
 
 This Act guarantees patient rights to participate in decentralized trials for the most promising treatment. It achieves
 this through a free, open-source, decentralized trial platform that eliminates billions in trial costs, rewards
@@ -7,7 +7,7 @@ companies for developing cures and prevention, and removes barriers to accessing
 ## 📜 SECTION 1. Core Problems & Solutions
 
 Today's healthcare system suffers from bureaucratic FDA delays, limited clinical trial access, exorbitant drug
-development costs, and a focus on expensive treatments. The Right to Trial Act solves these problems by:
+development costs, and a focus on expensive treatments. The Cure Acceleration Act solves these problems by:
 
 * **Guaranteeing universal access:** Every person has the right to try treatments after basic safety testing.
 * **Creating a free, open platform:** Eliminates billions in trial costs and accelerates development.
@@ -37,7 +37,7 @@ enables importation of treatments, fostering true price competition and preventi
 
 ## 🌟 SECTION 4. Benefits Over the Current System
 
-The Right to Trial Act offers significant advantages:
+The Cure Acceleration Act offers significant advantages:
 
 * **Cheaper:** Eliminates billions in costs, enables global price competition, and shares savings.
 * **Faster:** Removes years of delays, automates processes, and enables real-time monitoring.

--- a/public/globalSolutions/dfda/right-to-trial-act.md
+++ b/public/globalSolutions/dfda/right-to-trial-act.md
@@ -1,10 +1,10 @@
-# 💖 RIGHT TO TRIAL ACT
+# 💖 CURE ACCELERATION ACT
 
 ## 📜 SECTION 1. SHORT TITLE AND FINDINGS
 
 ### 1.1 📛 Title
 
-This Act may be cited as the **"Right to Trial Act"**.
+This Act may be cited as the **"Cure Acceleration Act"**.
 
 ### 1.2 🏥 Core Problems This Act Solves
 

--- a/public/letters/right-to-trial-act-call-to-action.md
+++ b/public/letters/right-to-trial-act-call-to-action.md
@@ -10,9 +10,9 @@ So here's the deal - our current system for developing new treatments is complet
 - 😢 60M people die each year because we don't have adequate treatments
 - 🤒 2.5B people suffer from chronic diseases we can't cure yet
 
-## 💡 The Solution: The Right to Trial Act
+## 💡 The Solution: The Cure Acceleration Act
 
-We've designed legislation called the Right to Trial Act that would:
+We've designed legislation called the Cure Acceleration Act that would:
 
 1. ✅ **Guarantee Universal Access** - Let any patient try treatments after basic safety testing
 2. 💻 **Free Open Decentralized Trials** - Eliminate billions in trial costs with decentralized infrastructure
@@ -59,4 +59,4 @@ The potential impact is massive - we could:
 - 💝 Help billions of suffering people
 - 🧬 Transform how we develop new cures
 
-P.S. Check out the details and sign our petition at [Right to Trial Act](https://wishonia.love/dfda/right-to-trial-act) 
+P.S. Check out the details and sign our petition at [Cure Acceleration Act](https://wishonia.love/dfda/right-to-trial-act) 

--- a/scripts/find-unused-deps.ps1
+++ b/scripts/find-unused-deps.ps1
@@ -7,7 +7,7 @@ $outputFile = ".\dep-analysis\unused-deps_$timestamp.txt"
 
 # Install depcheck locally if not already installed
 Write-Host "Installing depcheck locally..."
-#pnpm add -D depcheck
+pnpm add -D depcheck
 
 # Create the analysis script
 $analysisScript = @'


### PR DESCRIPTION
## Summary by Sourcery

Rename 'Right to Trial Act' to 'Cure Acceleration Act' throughout the codebase and documentation to ensure consistency and clarity. Remove outdated document on off-patent treatment incentives.

Enhancements:
- Rename 'Right to Trial Act' to 'Cure Acceleration Act' across multiple documents and components for consistency.

Documentation:
- Update documentation to reflect the renaming of the 'Right to Trial Act' to the 'Cure Acceleration Act'.

Chores:
- Remove the document discussing the lack of incentive to discover applications for off-patent treatments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Updated references throughout the application from "Right to Trial Act" to "Cure Acceleration Act," reflecting a shift in focus towards accelerating healthcare solutions.
  - Enhanced messaging in various components and documents to align with the new act's objectives.

- **Bug Fixes**
  - Clarified error handling in the SignPetitionButton component for improved user feedback during signing processes.

- **Documentation**
  - Comprehensive updates to multiple documents to reflect the new title and focus, including detailed insights into the new legislative framework and its implications for healthcare.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->