### PR TITLE
Add redirect for Right to Trial Act to Cure Acceleration Act

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,12 @@ const redirects = [
     permanent: true,
     description: "Redirect to new name of the Right to Trial Act",
   },
+  {
+    source: "/dfda/right-to-trial-act",
+    destination: "/dfda/cure-acceleration-act",
+    permanent: true,
+    description: "Redirect to new name of the Right to Trial Act",
+  },
   // Add more redirects here
   // Make sure to add the source path to the matcher array below 👇
 ] as const
@@ -91,5 +97,6 @@ export const config = {
     "/signin",
     "/signup",
     "/dfda/right-to-trial",
+    "/dfda/right-to-trial-act",
   ],
 }


### PR DESCRIPTION
Took 4 minutes

## Summary by Sourcery

Add a new redirect from '/dfda/right-to-trial-act' to '/dfda/cure-acceleration-act' in the middleware configuration, ensuring users are directed to the updated act name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new redirect from `/dfda/right-to-trial-act` to `/dfda/cure-acceleration-act`.
- **Configuration Updates**
	- Updated the routing configuration to include the new redirect path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->