### PR TITLE
Set build options and function limits in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,20 @@
       "path": "/api/cron/petition-summaries?type=weekly",
       "schedule": "0 9 * * 1"
     }
-  ]
+  ],
+  "build": {
+    "env": {
+      "NODE_OPTIONS": "--max-old-space-size=4096"
+    }
+  },
+  "functions": {
+    "app/api/**/*": {
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "app/**/*": {
+      "memory": 1024,
+      "maxDuration": 60
+    }
+  }
 } 


### PR DESCRIPTION
The purpose of this was to prevent out-of-memory exceptions when deploying to Vercel.


Added `NODE_OPTIONS` to increase memory for builds. Defined memory and execution time limits for API and app functions to ensure resource efficiency.

Took 8 minutes

## Summary by Sourcery

Configure resource limits for builds and functions.

Build:
- Set build options `NODE_OPTIONS` to increase memory limit during builds.

Deployment:
- Define memory and execution time limits for API and application functions.