### PR TITLE
Set Node.js memory limit in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
- 
+node-options=--max-old-space-size=4096 


### PR DESCRIPTION
Added a configuration to increase the memory limit used by Node.js to 4GB. This helps prevent memory-related issues during package management tasks, especially in large projects.

Took 28 seconds

## Summary by Sourcery

Build:
- Set `node-options` to `--max-old-space-size=4096` in the `.npmrc` file.