### PR TITLE
Remove Vercel Analytics configuration from next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,11 +36,7 @@ const nextConfig = {
         port: '',
       },
     ]
-  },
-  // Enable Vercel Analytics
-  analytics: {
-    enabled: true,
-  },
+  }
 }
 
 // Wrap nextConfig with withBundleAnalyzer


### PR DESCRIPTION
Vercel Analytics support was disabled by removing its configuration. This cleans up the code and ensures the feature is no longer active in the project.

Took 11 seconds

## Summary by Sourcery

Chores:
- Disable Vercel Analytics by removing its configuration from the Next.js configuration file.