### PR TITLE
Disable improve issues action

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -1,19 +1,6 @@
 name: Improve issues
 
 on:
-  issues:
-    types: [opened, edited]
+  workflow_dispatch:
 
 jobs:
-  gpt-comment:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: add useful comments to the new issue
-        uses: MaurerKrisztian/issue-improver-action@latest
-        with:
-          openai-key: ${{ secrets.OPENAPI_KEY }}
-          add-summary-section: true
-          add-related-issues-section: true
-          add-label-section: true


### PR DESCRIPTION
Remove the automatic execution of the `gpt-comment` job in the GitHub workflow for new issues.

* **Trigger**: Add a `workflow_dispatch` trigger to allow manual execution of the workflow.
* **Jobs**: Remove the `gpt-comment` job and its associated steps from the `jobs` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wishonia/wishonia/pull/254?shareId=eed9b520-1c0b-41a6-91ce-9e22db66b73c).