### PR TITLE
Fix production build OOM (SIGKILL) by serializing type-check and lint

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,18 @@ const nextConfig = {
 
     return config
   },
+  // Type checking and linting are run as separate, sequential steps by the
+  // `build` script instead of here. `next build` forks a worker for them while
+  // the parent process still holds the whole webpack heap, and with
+  // --max-old-space-size=4096 on both processes that exceeds the 8 GB Vercel
+  // build container and gets SIGKILLed. Running them before the compile keeps
+  // peak memory at max(check, compile) rather than the sum.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   // Configure `pageExtensions` to include MDX files
   pageExtensions: ['js', 'jsx', 'mdx', 'ts', 'tsx'],
   images: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "node scripts/run-next.js dev",
-    "build": "node scripts/run-next.js build",
+    "build": "pnpm run type-check && pnpm run lint && node scripts/run-next.js build",
+    "build:next": "node scripts/run-next.js build",
     "type-check": "tsc --noEmit",
     "turbo": "node scripts/run-next.js dev --turbo",
     "start": "node scripts/run-next.js start",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "node scripts/run-next.js dev",
     "build": "pnpm run type-check && pnpm run lint && node scripts/run-next.js build",
-    "build:next": "node scripts/run-next.js build",
-    "type-check": "tsc --noEmit",
+    "build:unsafe": "node scripts/run-next.js build",
+    "type-check": "tsc -p tsconfig.check.json --noEmit",
     "turbo": "node scripts/run-next.js dev --turbo",
     "start": "node scripts/run-next.js start",
     "lint": "next lint",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", ".next"]
+}


### PR DESCRIPTION
## Problem

Production deployments are failing with `out_of_memory` / `Command "pnpm run build" exited with SIGKILL` ([dpl_8rWT96fN9uA6ZsUTzrAURkLdGHDN](https://vercel.com/crowdsourcing-cures/wishonia/8rWT96fN9uA6ZsUTzrAURkLdGHDN)).

Build log timeline:

```
20:22:39   ✓ Compiled successfully
20:22:39     Linting and checking validity of types ...
20:24:05  Error: Command "pnpm run build" exited with SIGKILL
20:24:11  • At least one "Out of Memory" ("OOM") event was detected during the build.
```

## Root cause

The compile itself is fine. `next build` then forks a **worker** for type checking + linting *while the parent process still holds the entire webpack heap*. `NODE_OPTIONS=--max-old-space-size=4096` is applied to every Node process in the build (both `vercel.json` `build.env` and `.npmrc`), so the two processes together can reach ~8 GB — exactly the build container size (4 cores, 8 GB) — and the kernel SIGKILLs one of them.

Preview builds of byte-identical code passed (`96b7d69`, `40efc2a` both READY) because `next.config.js` only applies `withSentryConfig` when `VERCEL_ENV === "production"`. Production builds carry the extra Sentry source-map processing memory, which is what pushes the total over the limit. This also explains why production has been flip-flopping green/red across recent commits rather than failing deterministically.

## Fix

Run `tsc --noEmit` and `next lint` as sequential steps in the `build` script and turn off Next's in-build copies, so peak memory is `max(check, compile)` instead of `check + compile`.

Both checks still gate every deploy — only their scheduling changes. Verified locally against this tree: `tsc --noEmit` exits 0, `next lint` reports "No ESLint warnings or errors", so nothing was failing except memory.

`build:next` is added as an escape hatch to compile without re-running the checks.

## Note

Minor tradeoff: `tsc` now runs before `.next/types/**/*.ts` is generated, so Next's generated route-type validation isn't checked on a cold Vercel build. Everything in `tsconfig.json`'s `include` is still fully checked.

## Unrelated, but on a deadline

The same build log warns:

```
Error: Node.js version 20.x is deprecated. Deployments created on or after
2026-10-01 will fail to build. Please set Node.js Version to 24.x in Project Settings.
```

Not addressed here — worth a separate change well before that date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Serialize TypeScript type-checking and ESLint linting in the build pipeline to avoid out-of-memory failures during production Next.js builds.

New Features:
- Add a dedicated build:next script to run the Next.js compile without re-running type-checking and linting.

Enhancements:
- Configure Next.js to skip in-build TypeScript type-checking and ESLint linting, delegating them to separate pre-build scripts in package.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build & Quality**
  - Improved the build process by running type checks and linting before compilation.
  - Reduced peak memory usage during application builds.
  - Added a separate command for running the framework build directly when needed.
  - Updated type checking to use a dedicated configuration that excludes generated and dependency files.
  - Build failures are now identified earlier through explicit validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->