### PR TITLE
Fix mismatched background rails on the landing page at wide widths

### DIFF
--- a/app/(frontpage)/page.tsx
+++ b/app/(frontpage)/page.tsx
@@ -12,9 +12,13 @@ export const revalidate = 3600
 
 export default function Home() {
   return (
-      <main className="w-full mx-auto max-w-7xl overflow-x-hidden">
-          <div id="landing-content">
+      <main className="w-full overflow-x-hidden">
+          {/* InteractiveLandingPage and ManualHero paint their own bg-black, so
+              they sit outside the centered column and run the full width of the
+              viewport. Inside it, their background stopped at 1280px and left
+              rails of the page background down both edges on wide screens. */}
           <InteractiveLandingPage/>
+          <div id="landing-content" className="mx-auto w-full max-w-7xl">
           <ForkableWorldSection/>
           <HowItWorksSection/>
           <WorldOptimizationDashboard></WorldOptimizationDashboard>

--- a/app/(frontpage)/page.tsx
+++ b/app/(frontpage)/page.tsx
@@ -13,10 +13,9 @@ export const revalidate = 3600
 export default function Home() {
   return (
       <main className="w-full overflow-x-hidden">
-          {/* InteractiveLandingPage and ManualHero paint their own bg-black, so
-              they sit outside the centered column and run the full width of the
-              viewport. Inside it, their background stopped at 1280px and left
-              rails of the page background down both edges on wide screens. */}
+          {/* Outside the column on purpose: these paint their own bg-black and
+              must reach the viewport edges, or wide screens show rails of the
+              page background beside them. */}
           <InteractiveLandingPage/>
           <div id="landing-content" className="mx-auto w-full max-w-7xl">
           <ForkableWorldSection/>


### PR DESCRIPTION
## Problem

On wide screens the landing page shows vertical rails down the left and right edges in a different color than the hero. Measured on production at 2560x1400:

| Area | Color |
|---|---|
| Hero ("slideshow") center column, 1280px | `rgb(0, 0, 0)` — its own `bg-black` |
| Rails outside it | `rgb(10, 10, 10)` — the page background |

In light mode it is the same bug but much louder: the rails are pure white against the black hero.

## Cause

`<main>` carried `mx-auto max-w-7xl`, clamping everything to 1280px — including `InteractiveLandingPage` and `ManualHero`, the two sections that paint their own `bg-black`. Their background stopped at the column edge, so the page background showed through on either side.

`main` also has `overflow-x-hidden`, which is why the usual escape hatch does not work here: giving the hero `margin-left: calc(50% - 50vw)` makes it *measure* 2560px (`getBoundingClientRect().width === 2560`) but it still **paints** clipped to 1280px, because `overflow-x: hidden` makes `main` a scroll container. Worth knowing before anyone tries the negative-margin trick on this page.

## Fix

Every other section on the page already constrains itself — `mx-auto max-w-6xl` on three of them, `container` on the fourth — so `main`'s clamp was only doing work for the two black ones.

Moved the clamp from `main` onto the existing `#landing-content` wrapper, which now holds exactly the sections that want a column, and left the two full-bleed sections outside it. `#landing-content` had no references anywhere in the codebase (`grep` finds only its declaration), so reusing it costs nothing and avoids adding a div.

**No other widths change.** Measured after the fix at 2560px:

| Section | Before | After |
|---|---|---|
| InteractiveLandingPage | 1280 | 2560 (full bleed) |
| ForkableWorldSection | 1152 | 1152 |
| HowItWorksSection | 1152 | 1152 |
| WorldOptimizationDashboard | 1152 | 1152 |
| OpenSource (`container`) | 1280 | 1280 |
| ManualHero | 1280 | 2560 (full bleed) |

The hero content does not move: the column was already centered in the viewport, so centering within 2560px lands in the same place.

Simply deleting `max-w-7xl` from `main` was the smaller diff, but it would have widened the `container` section from 1280 to 1400 (this project sets `container.screens.2xl = 1400px`). That is arguably more consistent with the rest of the site, but it is not what this PR was asked to change, so I kept it pinned.

## Why not just recolor the hero

Making the hero `bg-background` so it matches the rails would break light mode. The site has `defaultTheme="dark" enableSystem` plus a theme toggle, and the hero is `bg-black text-white` — under `bg-background` it renders white text on a white background. Verified light mode is a real, working rendering today (the other sections correctly use dark text on white), so it cannot be treated as unreachable.

## Verification

Reproduced and fixed against production, both themes, at 2560x1400. After the change `document.documentElement.scrollWidth === window.innerWidth`, so no horizontal scrollbar is introduced. `tsc -p tsconfig.check.json --noEmit` exits 0 and `next lint` reports no warnings.

The preview deployment on this PR is worth a look at a wide window to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust landing page layout so hero sections can render full-bleed without mismatched background rails on wide screens.

Bug Fixes:
- Fix mismatched background rails beside the landing page hero on wide viewports by allowing hero sections to extend full width.

Enhancements:
- Move the max-width column constraint from the main element to the landing content wrapper so only non-hero sections remain centered and constrained.